### PR TITLE
Changes for CentOS 8 (Rocky/Alma Linux 8) operations

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -31,8 +31,8 @@ mod 'crayfishx/firewalld', '3.1.8'
 #mod 'adrien/network', :latest
 # recommended by NetComms
 mod 'razorsedge/network',
-  :git => 'https://github.com/m4rx0/puppet-network.git',
-  :ref => 'feature/puppet-6'
+  :git => 'https://github.com/uobdic/puppet-network.git',
+  :ref => 'feature/centos8'
 
 mod 'erwbgy/limits', :latest
 mod 'thias/tuned', :latest

--- a/Puppetfile
+++ b/Puppetfile
@@ -13,6 +13,7 @@ mod 'puppetlabs/firewall', :latest
 mod 'puppetlabs/inifile', :latest
 mod 'puppetlabs/mysql', :latest
 mod 'puppetlabs/ntp', :latest
+mod 'puppet-chrony', '2.3.0'
 mod 'puppet-selinux', '1.5.2'
 mod 'puppetlabs/stdlib', :latest
 mod 'puppetlabs/tftp', :latest

--- a/site/profile/manifests/base.pp
+++ b/site/profile/manifests/base.pp
@@ -2,8 +2,9 @@
 class profile::base {
   if $::facts['os']['release']['major'] == '8' {
     # RHEL 8
+    $chrony_servers = lookup('ntp::servers', Array, 'first', [])
     class { '::chrony':
-      servers => $ntp::servers,
+      servers => $chrony_servers,
     }
   } else {
     # RHEL 7

--- a/site/profile/manifests/base.pp
+++ b/site/profile/manifests/base.pp
@@ -1,6 +1,14 @@
 # the base profile should include component modules that will be on all nodes
 class profile::base {
-  class { '::ntp': }
+  if $::facts['os']['release']['major'] == '8' {
+    # RHEL 8
+    class { '::chrony':
+      servers => $ntp::servers,
+    }
+  } else {
+    # RHEL 7
+    class { '::ntp': }
+  }
 
   $packages_to_install = lookup('profile::default::packages_to_install', Array[String], 'unique', [])
   $packages_to_remove  = lookup('profile::default::packages_to_remove', Array[String], 'unique', [])

--- a/site/profile/manifests/monitored/central_log.pp
+++ b/site/profile/manifests/monitored/central_log.pp
@@ -6,6 +6,12 @@ class profile::monitored::central_log {
   $::ipaddress)
 
   unless $is_central_log {
+    file {'/etc/rsyslog.d':
+      ensure => 'directory',
+      owner  => 'root',
+      group  => 'root',
+      mode   => '0755',
+    }
     # remove obsolete configs
     file { [
               '/etc/rsyslog.d/central.conf',

--- a/site/profile/manifests/monitored/ganglia.pp
+++ b/site/profile/manifests/monitored/ganglia.pp
@@ -5,11 +5,16 @@ class profile::monitored::ganglia {
   $ganglia_cluster_name  = lookup('profile::monitored::ganglia_cluster_name', undef, undef, 'unknown')
   $ganglia_use_multicast = lookup('profile::monitored::ganglia_use_multicast', undef, undef, false)
 
+  if $::facts['os']['release']['major'] == '8' {
+    $ganglia_python_package = 'python3-ganglia-gmond'
+  } else {
+    $ganglia_python_package = 'ganglia-gmond-python'
+  }
   if $ganglia_cluster_name == 'unknown' {
 
   }
   elsif $ganglia_cluster_name == 'DICE' {
-    $ganglia_packages      = ['ganglia-gmond-python', 'ganglia', 'ganglia-gmond']
+    $ganglia_packages      = [$ganglia_python_package, 'ganglia', 'ganglia-gmond']
     $version = 'installed'
     package { $ganglia_packages:
       ensure          => $version,

--- a/site/site/manifests/basic.pp
+++ b/site/site/manifests/basic.pp
@@ -2,6 +2,7 @@
 class site::basic {
   $node_info = lookup('site::node_info', Hash, deep, {} )
   $site_info = lookup('site::site_info', Hash, deep, {} )
+  $dice = lookup('dice', Hash, deep, {} )
 
   # notify {'site::basic':
   #   message => "Applying site_info (${site_info}) and node_info (${node_info})"
@@ -37,5 +38,23 @@ class site::basic {
       group   => root,
       mode    => '0644',
     }
+  }
+
+  if $dice {
+    file {'/etc/dice':
+      ensure => 'directory',
+      owner  => 'root',
+      group  => 'root',
+      mode   => '0755',
     }
+
+    file { '/etc/dice/config.yaml':
+    ensure  => 'file',
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    content => template("${module_name}/dice_config.yaml.erb"),
+    require => File['/etc/dice'],
+    }
+  }
 }

--- a/site/site/manifests/basic.pp
+++ b/site/site/manifests/basic.pp
@@ -2,7 +2,11 @@
 class site::basic {
   $node_info = lookup('site::node_info', Hash, deep, {} )
   $site_info = lookup('site::site_info', Hash, deep, {} )
+  # TODO: all DICE parts will be in a separate puppet module
   $dice = lookup('dice', Hash, deep, {} )
+  $dice_computing_grid = lookup('dice::computing_grid', Hash, deep, {} )
+  $dice_storage = lookup('dice::storage', Hash, deep, {} )
+  $dice_glossary = lookup('dice::glossary', Hash, deep, {} )
 
   # notify {'site::basic':
   #   message => "Applying site_info (${site_info}) and node_info (${node_info})"

--- a/site/site/templates/dice_config.yaml.erb
+++ b/site/site/templates/dice_config.yaml.erb
@@ -1,0 +1,29 @@
+---
+<% if @dice -%>
+<% if @dice.key?('hdfs') -%>
+hdfs:
+<% info = @dice['hdfs'].to_yaml.split("\n") -%>
+<% info.drop(1).each do |line| -%>
+  <%= line %>
+<% end -%>
+<% end -%>
+<% end -%>
+
+<% if @site_info -%>
+site_info:
+<% info = @site_info.to_yaml.split("\n") -%>
+<% info.drop(1).each do |line| -%>
+  <%= line %>
+<% end -%>
+<% end %>
+
+<% if @node_info -%>
+node_info:
+<% info = @node_info.to_yaml.split("\n") -%>
+<% info.drop(1).each do |line| -%>
+  <%= line %>
+<% end -%>
+<% if @accounting_scale_factor -%>
+  accounting_scale_factor: <%=@accounting_scale_factor -%>
+<% end -%>
+<% end %>

--- a/site/site/templates/dice_config.yaml.erb
+++ b/site/site/templates/dice_config.yaml.erb
@@ -1,11 +1,8 @@
 ---
 <% if @dice -%>
-<% if @dice.key?('hdfs') -%>
-hdfs:
-<% info = @dice['hdfs'].to_yaml.split("\n") -%>
+<% info = @dice.to_yaml.split("\n") -%>
 <% info.drop(1).each do |line| -%>
-  <%= line %>
-<% end -%>
+<%= line %>
 <% end -%>
 <% end -%>
 

--- a/site/site/templates/dice_config.yaml.erb
+++ b/site/site/templates/dice_config.yaml.erb
@@ -6,6 +6,30 @@
 <% end -%>
 <% end -%>
 
+<% if @dice_computing_grid -%>
+computing_grid:
+<% info = @dice_computing_grid.to_yaml.split("\n") -%>
+<% info.drop(1).each do |line| -%>
+  <%= line %>
+<% end -%>
+<% end -%>
+
+<% if @dice_storage -%>
+storage:
+<% info = @dice_storage.to_yaml.split("\n") -%>
+<% info.drop(1).each do |line| -%>
+  <%= line %>
+<% end -%>
+<% end -%>
+
+<% if @dice_glossary -%>
+glossary:
+<% info = @dice_glossary.to_yaml.split("\n") -%>
+<% info.drop(1).each do |line| -%>
+  <%= line %>
+<% end -%>
+<% end -%>
+
 <% if @site_info -%>
 site_info:
 <% info = @site_info.to_yaml.split("\n") -%>


### PR DESCRIPTION
- [x] Test on Alma Linux 8.5
- [x] test on CentOS 7

## Changes:
- Puppet network module needed an update: CentOS 8 comes with (stable) NetworkManager by default. Let's keep it.
- `ntp` &rarr; `chrony`
- ganglia python modules have been ported to Python 3 &rarr; different package name for CentOS 8
- added `/etc/dice/config.yaml` for other development efforts