### PR TITLE
Updates and Improvements to CephFS, Firewall, and User Management 

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -5,7 +5,6 @@ classes:
  - 'profile::base'
  - 'profile::monitored'
  - profile::users::admin
- - profile::cephfs
 # - 'profile::firewall::setup'
 
 packages:
@@ -85,10 +84,3 @@ site::node_info:
   service_accounts: service_accounts
 
 cbsensor::version: "v7"
-
-profile::cephfs::keys:
-  - xrootd
-
-profile::cephfs::mounts:
-  '/xrootd':
-    device: dice-user@.dicefs=/xrootd

--- a/site/profile/manifests/cephfs.pp
+++ b/site/profile/manifests/cephfs.pp
@@ -62,15 +62,16 @@ class profile::cephfs (
     }
     # create bind mount to main mount point
     $mount_locations.each |$mount_location| {
-      file { "/cephfs/${mount_location}":
+      $mount_name = $mount_location[1, -1]
+      file { "/cephfs/${mount_name}":
         ensure  => directory,
       }
-      mount { "/cephfs/${mount_location}":
+      mount { "/cephfs/${mount_name}":
         ensure  => 'mounted',
         device  => $mount_location,
         fstype  => 'none',
         options => 'bind,nobootwait',
-        require => [File["/cephfs/${mount_location}"], Mount[$mount_location]],
+        require => [File["/cephfs/${mount_name}"], Mount[$mount_location]],
       }
     }
     if $facts['os']['release']['major'] == '9' {

--- a/site/profile/manifests/cephfs.pp
+++ b/site/profile/manifests/cephfs.pp
@@ -29,7 +29,7 @@ class profile::cephfs (
       owner   => 'root',
       group   => 'root',
       mode    => '0600',
-      require => [Package['ceph-common']],
+      require => [Package[$ceph_mount_dependency]],
     }
   }
 
@@ -39,7 +39,7 @@ class profile::cephfs (
     owner   => 'root',
     group   => 'root',
     mode    => '0644',
-    require => [Package['ceph-common']],
+    require => [Package[$ceph_mount_dependency]],
   }
 
   # create the mounts

--- a/site/profile/manifests/cephfs.pp
+++ b/site/profile/manifests/cephfs.pp
@@ -6,15 +6,20 @@ class profile::cephfs (
   Hash $mounts = {},
 ) {
   $ceph_release = $facts['os']['release']['major'] ? {
-    '7' => 'https://download.ceph.com/rpm-octopus/el7/noarch/ceph-release-1-1.el7.noarch.rpm',
+    '7' => 'ceph-release',
     default => 'centos-release-ceph-reef',
   }
   $ceph_mount_dependency = $facts['os']['release']['major'] ? {
     '7' => 'ceph-fuse',
     default => 'ceph-common',
   }
-
-  package { $ceph_release: }
+  if $facts['os']['release']['major'] == '7' {
+    package { $ceph_release:
+      name => 'https://download.ceph.com/rpm-octopus/el7/noarch/ceph-release-1-1.el7.noarch.rpm',
+    }
+  } else {
+    package { $ceph_release: }
+  }
   package { $ceph_mount_dependency:
     ensure          => latest,
     require         => [Package[$ceph_release]],

--- a/site/profile/manifests/cephfs.pp
+++ b/site/profile/manifests/cephfs.pp
@@ -5,24 +5,27 @@ class profile::cephfs (
   Array[String] $keys = ['dice-reader'],
   Hash $mounts = {},
 ) {
-  $ceph_release = $facts['os']['release']['major'] ? {
-    '7' => 'ceph-release',
-    default => 'centos-release-ceph-reef',
-  }
+  $ceph_release = 'centos-release-ceph-reef'
   $ceph_mount_dependency = $facts['os']['release']['major'] ? {
     '7' => 'ceph-fuse',
     default => 'ceph-common',
   }
   if $facts['os']['release']['major'] == '7' {
-    package { $ceph_release:
-      name => 'https://download.ceph.com/rpm-octopus/el7/noarch/ceph-release-1-1.el7.noarch.rpm',
+    file { '/etc/yum.repos.d/ceph.repo':
+      ensure => file,
+      source => 'puppet:///dice_store/cephfs/ceph_el7.repo',
+      owner  => 'root',
+      group  => 'root',
+      mode   => '0644',
     }
+    $ceph_repo_dependency = File['/etc/yum.repos.d/ceph.repo']
   } else {
     package { $ceph_release: }
+    $ceph_repo_dependency = Package[$ceph_release]
   }
   package { $ceph_mount_dependency:
     ensure          => latest,
-    require         => [Package[$ceph_release]],
+    require         => $ceph_repo_dependency,
     install_options => ['--enablerepo', 'epel'],
   }
 

--- a/site/profile/manifests/cephfs.pp
+++ b/site/profile/manifests/cephfs.pp
@@ -5,10 +5,20 @@ class profile::cephfs (
   Array[String] $keys = ['dice-reader'],
   Hash $mounts = {},
 ) {
-  package { 'centos-release-ceph-reef': }
-  package { 'ceph-common':
-    ensure  => latest,
-    require => [Package['centos-release-ceph-reef']],
+  $ceph_release = $facts['os']['release']['major'] ? {
+    '7' => 'https://download.ceph.com/rpm-octopus/el7/noarch/ceph-release-1-1.el7.noarch.rpm',
+    default => 'centos-release-ceph-reef',
+  }
+  $ceph_mount_dependency = $facts['os']['release']['major'] ? {
+    '7' => 'ceph-fuse',
+    default => 'ceph-common',
+  }
+
+  package { $ceph_release: }
+  package { $ceph_mount_dependency:
+    ensure     => latest,
+    require    => [Package[$ceph_release]],
+    enablerepo => 'epel',
   }
 
   # create the cephfs keys
@@ -47,15 +57,34 @@ class profile::cephfs (
       file { "/cephfs/${mount_location}":
         ensure  => link,
         target  => $mount_location,
-        require => File[$mount_location],
+        require => [File[$mount_location], Mount[$mount_location]],
       }
     }
-    $defaults = {
-      'require'  => [File['/etc/ceph/ceph.conf'], File[$mount_locations]],
-      'fstype'   => 'ceph',
-      'ensure'   => 'mounted',
-      'options'  => 'noatime,_netdev',
+    if $facts['os']['release']['major'] == '9' {
+      $defaults = {
+        'require'  => [File['/etc/ceph/ceph.conf'], File[$mount_locations]],
+        'fstype'   => 'ceph',
+        'ensure'   => 'mounted',
+        'options'  => 'noatime,_netdev',
+      }
+      create_resources('mount', $mounts, $defaults)
+    } else {
+      $ceph_fuse_mounts = $mounts.map |$mount, $options| {
+        # default options are of the form "dice-user@.dicefs=/dice"
+        # we want to extract the client ID before the '@' sign
+        $client_id = $options['device'].split('@')[0]
+        $ceph_fuse_mount = {
+          $mount => {
+            'ensure'  => 'mounted',
+            'device'  => 'none',
+            'fstype'  => 'ceph',
+            'options' => "ceph.id=${client_id},ceph.client_mountpoint=${mount},noatime,_netdev",
+            'require' => [File['/etc/ceph/ceph.conf'], File[$mount]],
+          },
+        }
+        $ceph_fuse_mount
+      }
+      create_resources('mount', $ceph_fuse_mounts)
     }
-    create_resources('mount', $mounts, $defaults)
   }
 }

--- a/site/profile/manifests/cephfs.pp
+++ b/site/profile/manifests/cephfs.pp
@@ -52,12 +52,17 @@ class profile::cephfs (
     file { $mount_locations:
       ensure => directory,
     }
-    # create symlink to main mount point
+    # create bind mount to main mount point
     $mount_locations.each |$mount_location| {
       file { "/cephfs/${mount_location}":
-        ensure  => link,
-        target  => $mount_location,
-        require => [File[$mount_location], Mount[$mount_location]],
+        ensure  => directory,
+      }
+      mount { "/cephfs/${mount_location}":
+        ensure  => 'mounted',
+        device  => $mount_location,
+        fstype  => 'none',
+        options => 'bind,nobootwait',
+        require => [File["/cephfs/${mount_location}"], Mount[$mount_location]],
       }
     }
     if $facts['os']['release']['major'] == '9' {

--- a/site/profile/manifests/cephfs.pp
+++ b/site/profile/manifests/cephfs.pp
@@ -86,11 +86,12 @@ class profile::cephfs (
         # default options are of the form "dice-user@.dicefs=/dice"
         # we want to extract the client ID before the '@' sign
         $client_id = $options['device'].split('@')[0]
+        $mount_point = $options['device'].split('=')[1]
         mount { $mount:
           ensure  => 'mounted',
           device  => 'none',
           fstype  => 'fuse.ceph',
-          options => "ceph.id=${client_id},ceph.client_mountpoint=${options['device']},noatime,_netdev",
+          options => "ceph.id=${client_id},ceph.client_mountpoint=${mount_point},noatime,_netdev",
           require => [File['/etc/ceph/ceph.conf'], File[$mount]],
         }
       }

--- a/site/profile/manifests/cephfs.pp
+++ b/site/profile/manifests/cephfs.pp
@@ -89,7 +89,7 @@ class profile::cephfs (
         mount { $mount:
           ensure  => 'mounted',
           device  => 'none',
-          fstype  => 'ceph',
+          fstype  => 'fuse.ceph',
           options => "ceph.id=${client_id},ceph.client_mountpoint=${options['device']},noatime,_netdev",
           require => [File['/etc/ceph/ceph.conf'], File[$mount]],
         }

--- a/site/profile/manifests/firewall.pp
+++ b/site/profile/manifests/firewall.pp
@@ -15,19 +15,19 @@ class profile::firewall {
     $drop_v6         = lookup('profile::firewall6::drop', Hash, 'deep', {})
 
     $accept_defaults = {
-      'action' => 'accept',
+      'jump' => 'accept',
     }
     $accept_defaults_v6 = {
-      'action' => 'accept',
+      'jump' => 'accept',
       'provider' => 'ip6tables',
     }
 
     $drop_defaults   = {
-      'action' => 'drop',
+      'jump' => 'drop',
       'proto' => 'all',
     }
     $drop_defaults_v6   = {
-      'action' => 'drop',
+      'jump' => 'drop',
       'provider' => 'ip6tables',
       'proto' => 'all',
     }

--- a/site/profile/manifests/firewall/default_rules.pp
+++ b/site/profile/manifests/firewall/default_rules.pp
@@ -64,62 +64,62 @@ class profile::firewall::default_rules {
     proto       => 'tcp',
     jump        => 'accept',
     destination => '137.222.9.43/32',
-    dport       => '2500-3300',
+    dport       => '2500:3300',
   }
 
   firewall { '400 allow Veeam restore help ports 2500-3300 172.26.5.15':
     proto       => 'tcp',
     jump        => 'accept',
     destination => '172.26.5.15/32',
-    dport       => '2500-3300',
+    dport       => '2500:3300',
   }
 
   firewall { '400 allow Veeam restore help ports 2500-3300 172.26.5.37':
     proto       => 'tcp',
     jump        => 'accept',
     destination => '172.26.5.37/32',
-    dport       => '2500-3300',
+    dport       => '2500:3300',
   }
 
   firewall { '400 allow Veeam restore help ports 2500-3300 172.26.7.8':
     proto       => 'tcp',
     jump        => 'accept',
     destination => '172.26.7.8/32',
-    dport       => '2500-3300',
+    dport       => '2500:3300',
   }
 
   firewall { '400 allow Veeam restore help ports 2500-3300 172.26.7.24':
     proto       => 'tcp',
     jump        => 'accept',
     destination => '172.26.7.24/32',
-    dport       => '2500-3300',
+    dport       => '2500:3300',
   }
 
   firewall { '400 allow Veeam restore help ports 2500-3300 172.27.5.16':
     proto       => 'tcp',
     jump        => 'accept',
     destination => '172.27.5.16/32',
-    dport       => '2500-3300',
+    dport       => '2500:3300',
   }
 
   firewall { '400 allow Veeam restore help ports 2500-3300 172.27.5.18':
     proto       => 'tcp',
     jump        => 'accept',
     destination => '172.27.5.18/32',
-    dport       => '2500-3300',
+    dport       => '2500:3300',
   }
 
   firewall { '400 allow Veeam restore help ports 2500-3300 172.27.5.22':
     proto       => 'tcp',
     jump        => 'accept',
     destination => '172.27.5.22/32',
-    dport       => '2500-3300',
+    dport       => '2500:3300',
   }
 
   firewall { '400 allow Veeam restore help ports 2500-3300 172.27.7.2':
     proto       => 'tcp',
     jump        => 'accept',
     destination => '172.27.7.2/32',
-    dport       => '2500-3300',
+    dport       => '2500:3300',
   }
 }

--- a/site/profile/manifests/firewall/default_rules.pp
+++ b/site/profile/manifests/firewall/default_rules.pp
@@ -2,123 +2,123 @@
 class profile::firewall::default_rules {
   firewall { '100 DROP UoB crash-probes WAS 100 accept SSH from CSE':
     proto  => 'all',
-    action => 'drop',
+    jump   => 'drop',
     source => '10.17.0.0/16',
   }
 
   firewall { '100 DROP UoB crash-probes':
     proto  => 'all',
-    action => 'drop',
+    jump   => 'drop',
     source => '10.18.0.0/15',
   }
 
   firewall { '101 trust SEIS subnet':
     proto  => 'all',
-    action => 'accept',
+    jump   => 'accept',
     source => '172.16.0.0/16',
   }
 
   firewall { '101 trust WIFI 1':
     proto  => 'all',
-    action => 'accept',
+    jump   => 'accept',
     source => '172.21.0.0/16',
   }
 
   firewall { '101 trust WIFI 2':
     proto  => 'all',
-    action => 'accept',
+    jump   => 'accept',
     source => '172.23.0.0/16',
   }
 
   firewall { '101 trust 5TA wired ntwk':
     proto  => 'all',
-    action => 'accept',
+    jump   => 'accept',
     source => '172.28.0.0/16',
   }
 
   firewall { '102 Trust UoB network':
     proto  => 'all',
-    action => 'accept',
+    jump   => 'accept',
     source => '137.222.0.0/16',
   }
 
   firewall { '103 Trust DICE network':
     proto  => 'all',
-    action => 'accept',
+    jump   => 'accept',
     source => '10.129.5.0/24',
   }
 
   firewall { '104 Trust SM network':
     proto  => 'all',
-    action => 'accept',
+    jump   => 'accept',
     source => '10.129.1.0/24',
   }
 
   firewall { '105 drop all-systems.mcast.net':
     proto       => 'igmp',
-    action      => 'drop',
+    jump        => 'drop',
     destination => '224.0.0.1',
   }
 
   firewall { '400 allow Veeam restore help ports 2500-3300 137.222.9.43':
     proto       => 'tcp',
-    action      => 'accept',
+    jump        => 'accept',
     destination => '137.222.9.43/32',
     dport       => '2500-3300',
   }
 
   firewall { '400 allow Veeam restore help ports 2500-3300 172.26.5.15':
     proto       => 'tcp',
-    action      => 'accept',
+    jump        => 'accept',
     destination => '172.26.5.15/32',
     dport       => '2500-3300',
   }
 
   firewall { '400 allow Veeam restore help ports 2500-3300 172.26.5.37':
     proto       => 'tcp',
-    action      => 'accept',
+    jump        => 'accept',
     destination => '172.26.5.37/32',
     dport       => '2500-3300',
   }
 
   firewall { '400 allow Veeam restore help ports 2500-3300 172.26.7.8':
     proto       => 'tcp',
-    action      => 'accept',
+    jump        => 'accept',
     destination => '172.26.7.8/32',
     dport       => '2500-3300',
   }
 
   firewall { '400 allow Veeam restore help ports 2500-3300 172.26.7.24':
     proto       => 'tcp',
-    action      => 'accept',
+    jump        => 'accept',
     destination => '172.26.7.24/32',
     dport       => '2500-3300',
   }
 
   firewall { '400 allow Veeam restore help ports 2500-3300 172.27.5.16':
     proto       => 'tcp',
-    action      => 'accept',
+    jump        => 'accept',
     destination => '172.27.5.16/32',
     dport       => '2500-3300',
   }
 
   firewall { '400 allow Veeam restore help ports 2500-3300 172.27.5.18':
     proto       => 'tcp',
-    action      => 'accept',
+    jump        => 'accept',
     destination => '172.27.5.18/32',
     dport       => '2500-3300',
   }
 
   firewall { '400 allow Veeam restore help ports 2500-3300 172.27.5.22':
     proto       => 'tcp',
-    action      => 'accept',
+    jump        => 'accept',
     destination => '172.27.5.22/32',
     dport       => '2500-3300',
   }
 
   firewall { '400 allow Veeam restore help ports 2500-3300 172.27.7.2':
     proto       => 'tcp',
-    action      => 'accept',
+    jump        => 'accept',
     destination => '172.27.7.2/32',
     dport       => '2500-3300',
   }

--- a/site/profile/manifests/firewall/post.pp
+++ b/site/profile/manifests/firewall/post.pp
@@ -25,7 +25,14 @@ class profile::firewall::post {
     jump       => 'LOG',
     log_prefix => '[iptables]: ',
     before     => undef,
-    protocol   => ['iptables', 'ip6tables'],
+    protocol   => 'iptables',
+  }
+  firewall { '99997 Log once all DROPs are done - IPv6':
+    proto      => 'all',
+    jump       => 'LOG',
+    log_prefix => '[iptables]: ',
+    before     => undef,
+    protocol   => 'ip6tables',
   }
 
   firewall { '99998 Reject anything else - IPv6':

--- a/site/profile/manifests/firewall/post.pp
+++ b/site/profile/manifests/firewall/post.pp
@@ -7,7 +7,7 @@ class profile::firewall::post {
     jump     => 'reject',
     reject   => 'icmp6-adm-prohibited',
     before   => undef,
-    provider => 'ip6tables',
+    protocol => 'ip6tables',
   }
 
   firewall { '199 Reject anything else':
@@ -16,7 +16,7 @@ class profile::firewall::post {
     jump     => 'reject',
     reject   => 'icmp-host-prohibited',
     before   => undef,
-    provider => 'iptables',
+    protocol => 'iptables',
   }
 
   # after everything
@@ -25,7 +25,7 @@ class profile::firewall::post {
     jump       => 'LOG',
     log_prefix => '[iptables]: ',
     before     => undef,
-    provider   => ['iptables', 'ip6tables'],
+    protocol   => ['iptables', 'ip6tables'],
   }
 
   firewall { '99998 Reject anything else - IPv6':
@@ -33,7 +33,7 @@ class profile::firewall::post {
     jump     => 'reject',
     reject   => 'icmp6-adm-prohibited',
     before   => undef,
-    provider => 'ip6tables',
+    protocol => 'ip6tables',
   }
 
   firewall { '99998 Reject anything else':
@@ -41,6 +41,6 @@ class profile::firewall::post {
     jump     => 'reject',
     reject   => 'icmp-host-prohibited',
     before   => undef,
-    provider => 'iptables',
+    protocol => 'iptables',
   }
 }

--- a/site/profile/manifests/firewall/post.pp
+++ b/site/profile/manifests/firewall/post.pp
@@ -4,7 +4,7 @@ class profile::firewall::post {
   firewall { '199 Reject anything else - IPv6':
     chain    => 'FORWARD',
     proto    => 'all',
-    action   => 'reject',
+    jump     => 'reject',
     reject   => 'icmp6-adm-prohibited',
     before   => undef,
     provider => 'ip6tables',
@@ -13,7 +13,7 @@ class profile::firewall::post {
   firewall { '199 Reject anything else':
     chain    => 'FORWARD',
     proto    => 'all',
-    action   => 'reject',
+    jump     => 'reject',
     reject   => 'icmp-host-prohibited',
     before   => undef,
     provider => 'iptables',
@@ -30,7 +30,7 @@ class profile::firewall::post {
 
   firewall { '99998 Reject anything else - IPv6':
     proto    => 'all',
-    action   => 'reject',
+    jump     => 'reject',
     reject   => 'icmp6-adm-prohibited',
     before   => undef,
     provider => 'ip6tables',
@@ -38,7 +38,7 @@ class profile::firewall::post {
 
   firewall { '99998 Reject anything else':
     proto    => 'all',
-    action   => 'reject',
+    jump     => 'reject',
     reject   => 'icmp-host-prohibited',
     before   => undef,
     provider => 'iptables',

--- a/site/profile/manifests/firewall/pre.pp
+++ b/site/profile/manifests/firewall/pre.pp
@@ -35,45 +35,45 @@ class profile::firewall::pre {
 
   # Default firewall rules
   firewall { '000 accept all icmp':
-    proto  => 'icmp',
-    action => 'accept',
+    proto => 'icmp',
+    jump  => 'accept',
   }
 
   firewall { '00001 accept all icmpv6':
-    proto  => 'ipv6-icmp',
-    action => 'accept',
+    proto => 'ipv6-icmp',
+    jump  => 'accept',
   }
 
   firewall { '001 accept all to lo interface':
     proto   => 'all',
     iniface => 'lo',
-    action  => 'accept',
+    jump    => 'accept',
   }
 
   firewall { '002 reject local traffic not on loopback interface':
     iniface     => '! lo',
     proto       => 'all',
     destination => '127.0.0.1/8',
-    action      => 'reject',
+    jump        => 'reject',
   }
 
   firewall { '0001 accept all to lo interface':
     proto    => 'all',
     iniface  => 'lo',
-    action   => 'accept',
+    jump     => 'accept',
     provider => 'ip6tables',
   }
 
   firewall { '003 accept related established rules':
-    proto  => 'all',
-    state  => ['RELATED', 'ESTABLISHED'],
-    action => 'accept',
+    proto => 'all',
+    state => ['RELATED', 'ESTABLISHED'],
+    jump  => 'accept',
   }
 
   firewall { '0003 accept related established rules':
     proto    => 'all',
     state    => ['RELATED', 'ESTABLISHED'],
-    action   => 'accept',
+    jump     => 'accept',
     provider => 'ip6tables',
   }
 }

--- a/site/profile/manifests/firewall/pre.pp
+++ b/site/profile/manifests/firewall/pre.pp
@@ -61,7 +61,7 @@ class profile::firewall::pre {
     proto    => 'all',
     iniface  => 'lo',
     jump     => 'accept',
-    provider => 'ip6tables',
+    protocol => 'ip6tables',
   }
 
   firewall { '003 accept related established rules':
@@ -74,6 +74,6 @@ class profile::firewall::pre {
     proto    => 'all',
     state    => ['RELATED', 'ESTABLISHED'],
     jump     => 'accept',
-    provider => 'ip6tables',
+    protocol => 'ip6tables',
   }
 }

--- a/site/profile/manifests/users.pp
+++ b/site/profile/manifests/users.pp
@@ -69,7 +69,7 @@ class profile::users {
         if $value['ensure'] == 'absent' and "/home/${key}" != $value['home'] {
           exec { "remove_home_symlink_${key}":
             command => "/usr/bin/rm -f /home/${key}",
-            unless  => "/usr/bin/test -d /home/${key}",
+            unless  => "/usr/bin/test ! -d /home/${key}",
           }
         }
       }


### PR DESCRIPTION
This pull request introduces a series of updates across CephFS mounts, firewall rules, and user management within our configurations. Detailed changes are grouped by category as follows:

### CephFS
- **CentOS 7 Mounts:** Enhanced mount support for CentOS 7 including simplified creation processes and adjustments to match current package names and source changes.
  - Adjusted the mount point and bind mount locations for EL7, fixing issues with duplicated paths.

### Firewall
- **Rule and Parameter Updates:** Modernized the firewall configurations to better align with software version updates and optimized rule management.
  - Changed rule action to 'jump' from a direct action.
  - Updated parameters to match the newer firewall software version 8.
  - Split previously joined IPv4 and IPv6 rules as the joint handling was deprecated.
  - Updated notation for specifying port ranges to align with preferred standards.

### User Management
- **Symlink Management:** Fixed an issue with symlink deletion under the user profiles management.

