### PR TITLE
rsyslog: add rate limit for automount messages

### DIFF
--- a/site/profile/templates/etc/rsyslog.conf.erb
+++ b/site/profile/templates/etc/rsyslog.conf.erb
@@ -41,6 +41,9 @@ $IncludeConfig /etc/rsyslog.d/*.conf
 
 :msg, contains, "veth" stop
 
+# limit the rate of "do_mount_indirect" messages to 1 per 10 minutes
+if ($msg contains "do_mount_indirect") then { Action(type="omfile" dirCreateMode="0700" FileCreateMode="0644" File="/var/log/do_mount_indirect.log" execOnlyOnceEveryInterval=600) stop }
+
 # Log all kernel messages to the console.
 # Logging much else clutters up the screen.
 #kern.*                                                 /dev/console


### PR DESCRIPTION
Limit messages from automount regarding `do_mount_indirect` to 1 per 10 minutes and write them to a separate file.
These messages will no longer be forwarded to central logs