### PR TITLE
Adjust pool accounts for grid-use

### DIFF
--- a/site/profile/files/home/bashrc
+++ b/site/profile/files/home/bashrc
@@ -1,0 +1,28 @@
+# .bashrc
+# This file is managed by Puppet.  Changes will be overwritten.
+# Please edit ~/.bashrc.custom instead of this file!
+
+# User specific aliases and functions
+
+alias rm='rm -i'
+alias cp='cp -i'
+alias mv='mv -i'
+alias ll='ls -la'
+
+# Set the prompt
+PS1='\u@\h:\w\$ '
+
+# Source global definitions
+if [ -f /etc/bashrc ]; then
+  . /etc/bashrc
+fi
+
+# Puppet specific definitions
+if [ -f /etc/bashrc.puppet ]; then
+  . /etc/bashrc.puppet
+fi
+
+# Account holder definitions
+if [ -f ~/.bashrc.custom ]; then
+  . ~/.bashrc.custom
+fi

--- a/site/profile/manifests/users/poolaccounts.pp
+++ b/site/profile/manifests/users/poolaccounts.pp
@@ -16,7 +16,7 @@ class profile::users::poolaccounts (
     'gid'           => '100',
     'group'         => 'users',
     'tag'           => 'poolaccounts::users',
-    'bashrc_source' => 'puppet:///modules/accounts/shell/bashrc',
+    'bashrc_source' => "puppet:///modules/${module_name}/home/bashrc",
   }
   create_resources('group', $groups, $defaults)
   create_resources('accounts::user', $users, $acc_defaults)

--- a/site/profile/manifests/users/poolaccounts.pp
+++ b/site/profile/manifests/users/poolaccounts.pp
@@ -12,7 +12,7 @@ class profile::users::poolaccounts (
     'shell'        => '/sbin/nologin',
     'password'     => '!!',
     'create_group' => false,
-    'managehome'   => false,
+    'managehome'   => true,
     'gid'          => '100',
     'group'        => 'users',
     'tag'          => 'poolaccounts::users',

--- a/site/profile/manifests/users/poolaccounts.pp
+++ b/site/profile/manifests/users/poolaccounts.pp
@@ -8,14 +8,15 @@ class profile::users::poolaccounts (
     'tag'    => 'poolaccounts::groups',
   }
   $acc_defaults = {
-    'ensure'       => present,
-    'shell'        => '/sbin/nologin',
-    'password'     => '!!',
-    'create_group' => false,
-    'managehome'   => true,
-    'gid'          => '100',
-    'group'        => 'users',
-    'tag'          => 'poolaccounts::users',
+    'ensure'        => present,
+    'shell'         => '/sbin/nologin',
+    'password'      => '!!',
+    'create_group'  => false,
+    'managehome'    => true,
+    'gid'           => '100',
+    'group'         => 'users',
+    'tag'           => 'poolaccounts::users',
+    'bashrc_source' => 'puppet:///modules/accounts/shell/bashrc',
   }
   create_resources('group', $groups, $defaults)
   create_resources('accounts::user', $users, $acc_defaults)


### PR DESCRIPTION
Changes affect pool accounts
-  /home is not managed
- custom bashrc is provided (can be expanded in the future)