### PR TITLE
Revert to upstream Veeam module

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -107,10 +107,8 @@ mod 'puppetlabs-apt', '9.4.0'
 
 # Veeam
 mod 'veeam_restore_client',
-  # :git => 'https://gitlab.services.bris.ac.uk/services-operations-public/veeam_restore_client.git',
-  # :ref => '1.5.2'
-  :git => 'git@gitlab.services.bris.ac.uk:pp-computing/veeam_restore_client.git',
-  :ref => 'kreczko-modern-stdlib'
+  :git => 'https://gitlab.services.bris.ac.uk/services-operations-public/veeam_restore_client.git',
+  :ref => '1.5.5'
 
 # NFS
 mod 'derdanne-nfs', '2.1.11'


### PR DESCRIPTION
The local Veeam module was created to use more modern stdlib functions; the legacy functions have now been removed from the upstream module, so we can revert to tracking that.