### PR TITLE
Faster firewall rules for public nodes

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -21,7 +21,7 @@ mod 'puppet/fetchcrl', :latest
 mod 'jhoblitt/mcelog', :latest
 mod 'jhoblitt-ipmi', '5.3.1'
 mod 'saz/memcached', :latest
-mod 'puppet-firewalld', '5.0.0'
+mod 'puppet-firewalld', '5.1.0'
 mod 'puppet-network', '2.2.0'
 # voxpupuli, see https://wikis.bris.ac.uk/display/BristolT2/Puppet+modules#Puppetmodules-Network
 #mod 'adrien/network', :latest

--- a/site/profile/lib/puppet/functions/profile/collapse_ipset_entries.rb
+++ b/site/profile/lib/puppet/functions/profile/collapse_ipset_entries.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'ipaddr'
+
+Puppet::Functions.create_function(:'profile::collapse_ipset_entries') do
+  dispatch :collapse_entries do
+    param 'Array[String]', :entries
+    return_type 'Array[String]'
+  end
+
+  def collapse_entries(entries)
+    nets = entries.map do |s|
+      begin
+        IPAddr.new(s).to_string + "/" + s.split("/")[1]
+      rescue StandardError
+        s
+      end
+    end.uniq
+
+    parsed = nets.map do |s|
+      ip, prefix = s.split("/", 2)
+      {
+        original: s,
+        ipaddr: IPAddr.new(ip),
+        prefix: Integer(prefix),
+      }
+    end
+
+    # sort broader networks first
+    parsed.sort_by! do |n|
+      [n[:ipaddr].ipv4? ? 4 : 6, n[:ipaddr].to_i, n[:prefix]]
+    end
+
+    kept = []
+
+    parsed.each do |candidate|
+      covered = kept.any? do |existing|
+        next false unless existing[:ipaddr].ipv4? == candidate[:ipaddr].ipv4?
+
+        mask_bits = existing[:ipaddr].ipv4? ? 32 : 128
+        next false if existing[:prefix] > candidate[:prefix]
+
+        existing_net = IPAddr.new("#{existing[:ipaddr].to_string}/#{existing[:prefix]}")
+        candidate_net = IPAddr.new("#{candidate[:ipaddr].to_string}/#{candidate[:prefix]}")
+
+        existing_net.include?(candidate_net.to_range.begin) &&
+          existing_net.include?(candidate_net.to_range.end)
+      end
+
+      kept << candidate unless covered
+    end
+
+    kept.map { |n| "#{n[:ipaddr].to_string}/#{n[:prefix]}" }
+  end
+end

--- a/site/profile/lib/puppet/functions/profile/collapse_ipset_entries.rb
+++ b/site/profile/lib/puppet/functions/profile/collapse_ipset_entries.rb
@@ -9,16 +9,22 @@ Puppet::Functions.create_function(:'profile::collapse_ipset_entries') do
   end
 
   def collapse_entries(entries)
-    nets = entries.map do |s|
-      begin
-        IPAddr.new(s).to_string + "/" + s.split("/")[1]
-      rescue StandardError
-        s
-      end
+    normalized = entries.map do |s|
+      ip, prefix = s.split('/', 2)
+      ipaddr = IPAddr.new(ip)
+
+      prefix_len =
+        if prefix.nil? || prefix.empty?
+          ipaddr.ipv4? ? 32 : 128
+        else
+          Integer(prefix)
+        end
+
+      "#{ipaddr.to_string}/#{prefix_len}"
     end.uniq
 
-    parsed = nets.map do |s|
-      ip, prefix = s.split("/", 2)
+    parsed = normalized.map do |s|
+      ip, prefix = s.split('/', 2)
       {
         original: s,
         ipaddr: IPAddr.new(ip),
@@ -26,9 +32,12 @@ Puppet::Functions.create_function(:'profile::collapse_ipset_entries') do
       }
     end
 
-    # sort broader networks first
     parsed.sort_by! do |n|
-      [n[:ipaddr].ipv4? ? 4 : 6, n[:ipaddr].to_i, n[:prefix]]
+      [
+        n[:ipaddr].ipv4? ? 4 : 6,
+        n[:ipaddr].to_i,
+        n[:prefix],
+      ]
     end
 
     kept = []
@@ -36,8 +45,6 @@ Puppet::Functions.create_function(:'profile::collapse_ipset_entries') do
     parsed.each do |candidate|
       covered = kept.any? do |existing|
         next false unless existing[:ipaddr].ipv4? == candidate[:ipaddr].ipv4?
-
-        mask_bits = existing[:ipaddr].ipv4? ? 32 : 128
         next false if existing[:prefix] > candidate[:prefix]
 
         existing_net = IPAddr.new("#{existing[:ipaddr].to_string}/#{existing[:prefix]}")

--- a/site/profile/lib/puppet/functions/profile/firewalld_ipset_candidate.rb
+++ b/site/profile/lib/puppet/functions/profile/firewalld_ipset_candidate.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+Puppet::Functions.create_function(:'profile::firewalld_ipset_candidate') do
+  # Decide whether a rule is eligible for ipset handling:
+  # - Must be a Hash
+  # - Must have a non-empty 'source'
+  # - family defaults to 'ipv4' and must be ipv4/ipv6
+  # - Must not include additional match keys like port/service/protocol/etc.
+  #
+  # @param rule [Hash] The rule hash from Hiera
+  # @return [Boolean] true if it is "source-only" and can go into ipsets
+  dispatch :firewalld_ipset_candidate do
+    param 'Hash', :rule
+    return_type 'Boolean'
+  end
+
+  def firewalld_ipset_candidate(rule)
+    family = rule.key?('family') && rule['family'] ? rule['family'].to_s : 'ipv4'
+    return false unless %w[ipv4 ipv6].include?(family)
+
+    source = rule['source']
+    return false if source.nil? || source.to_s.strip.empty?
+
+    extra_keys = %w[
+      port service protocol icmp_block masquerade forward_port log audit limit
+    ]
+
+    has_extras = extra_keys.any? { |k| !rule[k].nil? }
+    !has_extras
+  end
+end

--- a/site/profile/manifests/firewalld.pp
+++ b/site/profile/manifests/firewalld.pp
@@ -14,8 +14,6 @@
 #     port/service/protocol/... (optional)
 #
 class profile::firewalld (
-  Hash   $accepts        = lookup('profile::firewalld::accepts', Hash, 'deep', {}),
-  Hash   $drops          = lookup('profile::firewalld::drops',   Hash, 'deep', {}),
   String $zone           = 'public',
   String $notes_path     = '/etc/dice/firewalld_notes.txt',
   String $ipset_prefix   = 'dice',
@@ -23,6 +21,9 @@ class profile::firewalld (
   Integer $accept_priority = 60,
 ) {
   include firewalld
+
+  $accepts = lookup('profile::firewalld::accepts', Hash, 'deep', {})
+  $drops   = lookup('profile::firewalld::drops',   Hash, 'deep', {})
 
   $accepts_ipset = $accepts.filter |$title, $rule| {
     $rule =~ Hash and profile::firewalld_ipset_candidate($rule)
@@ -49,8 +50,8 @@ class profile::firewalld (
     accept_priority => $accept_priority,
   }
 
-  notice("accepts_ipset=${accepts_ipset.length} accepts_rich=${accepts_rich.length}")
-  notice("drops_ipset=${drops_ipset.length} drops_rich=${drops_rich.length}")
+  warning("accepts_ipset=${accepts_ipset.length} accepts_rich=${accepts_rich.length}")
+  warning("drops_ipset=${drops_ipset.length} drops_rich=${drops_rich.length}")
   # 2) Everything else -> normal rich rules (as you do today)
   $accept_defaults = { ensure => present, zone => $zone, action => 'accept' }
   $drop_defaults   = { ensure => present, zone => $zone, action => 'drop' }

--- a/site/profile/manifests/firewalld.pp
+++ b/site/profile/manifests/firewalld.pp
@@ -49,6 +49,8 @@ class profile::firewalld (
     accept_priority => $accept_priority,
   }
 
+  notice("accepts_ipset=${accepts_ipset.length} accepts_rich=${accepts_rich.length}")
+  notice("drops_ipset=${drops_ipset.length} drops_rich=${drops_rich.length}")
   # 2) Everything else -> normal rich rules (as you do today)
   $accept_defaults = { ensure => present, zone => $zone, action => 'accept' }
   $drop_defaults   = { ensure => present, zone => $zone, action => 'drop' }

--- a/site/profile/manifests/firewalld.pp
+++ b/site/profile/manifests/firewalld.pp
@@ -50,8 +50,6 @@ class profile::firewalld (
     accept_priority => $accept_priority,
   }
 
-  warning("accepts_ipset=${accepts_ipset.length} accepts_rich=${accepts_rich.length}")
-  warning("drops_ipset=${drops_ipset.length} drops_rich=${drops_rich.length}")
   # 2) Everything else -> normal rich rules (as you do today)
   $accept_defaults = { ensure => present, zone => $zone, action => 'accept' }
   $drop_defaults   = { ensure => present, zone => $zone, action => 'drop' }

--- a/site/profile/manifests/firewalld.pp
+++ b/site/profile/manifests/firewalld.pp
@@ -1,21 +1,17 @@
 # profile::firewalld
 #
-# Efficient source allow/deny lists for firewalld using ipsets + a small number of rich rules.
+# Partitions firewalld rules into:
+#  - Source-only rules (family+source only) -> enforced via ipsets + 2–4 rich rules total
+#  - Everything else (icmp/ports/services/complex matches) -> enforced as normal firewalld_rich_rule resources
 #
-# Data model (Hiera):
-#   profile::firewalld::accepts:
-#     "Human-readable reason (CIDR)":
-#       family: ipv4|ipv6   # optional (defaults to ipv4)
-#       source: "1.2.3.0/24" or "2a03:2880::/29"   # required
-#       priority: 100       # optional (used only for notes; ipset rules use fixed priorities)
-#
-#   profile::firewalld::drops: (same structure)
-#
-# Parameters:
-#   - zone: Firewalld zone to attach the ipset rich rules to (default: public)
-#   - notes_path: Where to write a human-readable list of entries with reasons
-#   - ipset_prefix: Prefix for created ipset names/files (default: dice)
-#   - drop_priority / accept_priority: Rich rule priorities for the ipset-based rules
+# Hiera input:
+#   profile::firewalld::accepts / profile::firewalld::drops
+# Each is a hash:
+#   "Human readable title":
+#     family: ipv4|ipv6    (optional, defaults to ipv4)
+#     source: CIDR         (optional depending on rule)
+#     priority: int        (optional)
+#     port/service/protocol/... (optional)
 #
 class profile::firewalld (
   Hash   $accepts        = lookup('profile::firewalld::accepts', Hash, 'deep', {}),
@@ -28,13 +24,35 @@ class profile::firewalld (
 ) {
   include firewalld
 
+  $accepts_ipset = $accepts.filter |$title, $rule| {
+    $rule =~ Hash and profile::firewalld_ipset_candidate($rule)
+  }
+  $accepts_rich = $accepts.filter |$title, $rule| {
+    !($rule =~ Hash and profile::firewalld_ipset_candidate($rule))
+  }
+
+  $drops_ipset = $drops.filter |$title, $rule| {
+    $rule =~ Hash and profile::firewalld_ipset_candidate($rule)
+  }
+  $drops_rich = $drops.filter |$title, $rule| {
+    !($rule =~ Hash and profile::firewalld_ipset_candidate($rule))
+  }
+
+  # 1) Source-only rules -> ipsets + small number of rich rules
   profile::firewalld::ipsets { 'ipset-lists':
-    accepts         => $accepts,
-    drops           => $drops,
+    accepts         => $accepts_ipset,
+    drops           => $drops_ipset,
     zone            => $zone,
     notes_path      => $notes_path,
     ipset_prefix    => $ipset_prefix,
     drop_priority   => $drop_priority,
     accept_priority => $accept_priority,
   }
+
+  # 2) Everything else -> normal rich rules (as you do today)
+  $accept_defaults = { ensure => present, zone => $zone, action => 'accept' }
+  $drop_defaults   = { ensure => present, zone => $zone, action => 'drop' }
+
+  create_resources('firewalld_rich_rule', $accepts_rich, $accept_defaults)
+  create_resources('firewalld_rich_rule', $drops_rich,   $drop_defaults)
 }

--- a/site/profile/manifests/firewalld.pp
+++ b/site/profile/manifests/firewalld.pp
@@ -1,39 +1,40 @@
-# Class for configuring firewalld
-# Takes rules in the form of
-# profile::firewalld::accepts:
-#  'allow ssh from XXX':
-#    family: 'ipv4'
-#    source: 'XXX'
-#    protocol: 'tcp'
-# profile::firewalld::drops:
-#  'drop ssh from YYY':
-#    family: 'ipv6'
-#    source: 'YYY'
-#    protocol: 'all'
-class profile::firewalld {
-  $supported_distro = "${facts['os']['family']}-${facts['os']['release']['major']}" ? {
-    default        => false,
-    /RedHat-(8|9)/ => true,
-  }
+# profile::firewalld
+#
+# Efficient source allow/deny lists for firewalld using ipsets + a small number of rich rules.
+#
+# Data model (Hiera):
+#   profile::firewalld::accepts:
+#     "Human-readable reason (CIDR)":
+#       family: ipv4|ipv6   # optional (defaults to ipv4)
+#       source: "1.2.3.0/24" or "2a03:2880::/29"   # required
+#       priority: 100       # optional (used only for notes; ipset rules use fixed priorities)
+#
+#   profile::firewalld::drops: (same structure)
+#
+# Parameters:
+#   - zone: Firewalld zone to attach the ipset rich rules to (default: public)
+#   - notes_path: Where to write a human-readable list of entries with reasons
+#   - ipset_prefix: Prefix for created ipset names/files (default: dice)
+#   - drop_priority / accept_priority: Rich rule priorities for the ipset-based rules
+#
+class profile::firewalld (
+  Hash   $accepts        = lookup('profile::firewalld::accepts', Hash, 'deep', {}),
+  Hash   $drops          = lookup('profile::firewalld::drops',   Hash, 'deep', {}),
+  String $zone           = 'public',
+  String $notes_path     = '/etc/dice/firewalld_notes.txt',
+  String $ipset_prefix   = 'dice',
+  Integer $drop_priority = 50,
+  Integer $accept_priority = 60,
+) {
+  include firewalld
 
-  if $supported_distro {
-    include firewalld
-
-    $accept = lookup('profile::firewalld::accepts', Hash, 'deep', {})
-    $drop   = lookup('profile::firewalld::drops', Hash, 'deep', {})
-
-    $accept_defaults = {
-      'ensure'   => present,
-      'zone'   => 'public',
-      'action'   => 'accept',
-    }
-    create_resources('firewalld_rich_rule', $accept, $accept_defaults)
-
-    $drop_defaults = {
-      'ensure'   => present,
-      'zone'   => 'public',
-      'action'   => 'drop',
-    }
-    create_resources('firewalld_rich_rule', $drop, $drop_defaults)
+  profile::firewalld::ipsets { 'ipset-lists':
+    accepts         => $accepts,
+    drops           => $drops,
+    zone            => $zone,
+    notes_path      => $notes_path,
+    ipset_prefix    => $ipset_prefix,
+    drop_priority   => $drop_priority,
+    accept_priority => $accept_priority,
   }
 }

--- a/site/profile/manifests/firewalld/ipset.pp
+++ b/site/profile/manifests/firewalld/ipset.pp
@@ -23,7 +23,7 @@ define profile::firewalld::ipset (
     'ipv6' => 'inet6',
   }
 
-  $ipset_name = "${ipset_prefix}-${title}-${family}"
+  $ipset_name = "${ipset_prefix}-${family}"
   $ipset_file = "/etc/firewalld/ipsets/${ipset_name}.xml"
 
   file { $ipset_file:
@@ -35,7 +35,10 @@ define profile::firewalld::ipset (
         'entries' => $entries,
     }),
     notify  => Exec['firewalld-reload-for-ipsets'],
-    require => File['/etc/firewalld/ipsets'],
+    require => [
+      File[$ipset_file],
+      Exec['firewalld-reload-for-ipsets'],
+    ],
   }
 
   firewalld_rich_rule { "DICE ipset ${title} ${family}":

--- a/site/profile/manifests/firewalld/ipset.pp
+++ b/site/profile/manifests/firewalld/ipset.pp
@@ -23,7 +23,7 @@ define profile::firewalld::ipset (
     'ipv6' => 'inet6',
   }
 
-  $ipset_name = "${ipset_prefix}-${family}"
+  $ipset_name = "${ipset_prefix}-${title}-${family}"
   $ipset_file = "/etc/firewalld/ipsets/${ipset_name}.xml"
 
   file { $ipset_file:

--- a/site/profile/manifests/firewalld/ipset.pp
+++ b/site/profile/manifests/firewalld/ipset.pp
@@ -35,10 +35,6 @@ define profile::firewalld::ipset (
         'entries' => $entries,
     }),
     notify  => Exec['firewalld-reload-for-ipsets'],
-    require => [
-      File[$ipset_file],
-      Exec['firewalld-reload-for-ipsets'],
-    ],
   }
 
   firewalld_rich_rule { "DICE ipset ${title} ${family}":
@@ -48,6 +44,6 @@ define profile::firewalld::ipset (
     source   => { 'ipset' => $ipset_name },
     action   => $action,
     priority => $priority,
-    require  => File[$ipset_file],
+    require  => [File[$ipset_file], Exec['firewalld-reload-for-ipsets'],],
   }
 }

--- a/site/profile/manifests/firewalld/ipset.pp
+++ b/site/profile/manifests/firewalld/ipset.pp
@@ -23,7 +23,7 @@ define profile::firewalld::ipset (
     'ipv6' => 'inet6',
   }
 
-  $ipset_name = "${ipset_prefix}-${title}-${family}"
+  $ipset_name = "${ipset_prefix}-${action}-${family}"
   $ipset_file = "/etc/firewalld/ipsets/${ipset_name}.xml"
 
   file { $ipset_file:

--- a/site/profile/manifests/firewalld/ipset.pp
+++ b/site/profile/manifests/firewalld/ipset.pp
@@ -1,0 +1,50 @@
+# profile::firewalld::ipset
+#
+# Manage a single firewalld ipset and the rich rule referencing it.
+#
+# Parameters:
+# @param family       - ipv4 or ipv6
+# @param entries      - array of CIDRs
+# @param action       - accept or drop
+# @param zone         - firewalld zone
+# @param priority     - rich rule priority
+# @param ipset_prefix - prefix for ipset names (e.g. "dice")
+#
+define profile::firewalld::ipset (
+  Array[String] $entries,
+  String $family,
+  String $action,
+  String $zone,
+  Integer $priority,
+  String $ipset_prefix = 'dice',
+) {
+  $xml_family = $family ? {
+    'ipv4' => 'inet',
+    'ipv6' => 'inet6',
+  }
+
+  $ipset_name = "${ipset_prefix}-${title}-${family}"
+  $ipset_file = "/etc/firewalld/ipsets/${ipset_name}.xml"
+
+  file { $ipset_file:
+    ensure  => file,
+    mode    => '0644',
+    content => epp('profile/firewalld/ipset.xml.epp', {
+        'name'    => $ipset_name,
+        'family'  => $xml_family,
+        'entries' => $entries,
+    }),
+    notify  => Exec['firewalld-reload-for-ipsets'],
+    require => File['/etc/firewalld/ipsets'],
+  }
+
+  firewalld_rich_rule { "DICE ipset ${title} ${family}":
+    ensure   => present,
+    zone     => $zone,
+    family   => $family,
+    source   => { 'ipset' => $ipset_name },
+    action   => $action,
+    priority => $priority,
+    require  => File[$ipset_file],
+  }
+}

--- a/site/profile/manifests/firewalld/ipsets.pp
+++ b/site/profile/manifests/firewalld/ipsets.pp
@@ -1,0 +1,107 @@
+# profile::firewalld::ipsets
+#
+# Turns many per-CIDR rich rules into:
+#   - up to 4 ipset XML files (accept/drop × inet/inet6)
+#   - up to 4 rich rules that reference those ipsets
+#   - a notes file preserving the original titles (reasons)
+#
+# It only creates an ipset + rule if there is at least one entry for that family.
+#
+define profile::firewalld::ipsets (
+  Hash   $accepts,
+  Hash   $drops,
+  String $zone,
+  String $notes_path,
+  String $ipset_prefix = 'dice',
+  Integer $drop_priority = 50,
+  Integer $accept_priority = 60,
+) {
+  # Normalize incoming hashes into arrays of {title,family,source,priority}
+  $accept_entries = $accepts.map |$title, $rule| {
+    {
+      'title'    => $title,
+      'family'   => pick($rule['family'], 'ipv4'),
+      'source'   => $rule['source'],
+      'priority' => $rule['priority'],
+    }
+  }
+
+  $drop_entries = $drops.map |$title, $rule| {
+    {
+      'title'    => $title,
+      'family'   => pick($rule['family'], 'ipv4'),
+      'source'   => $rule['source'],
+      'priority' => $rule['priority'],
+    }
+  }
+
+  $accept_v4_nets = $accept_entries.filter |$e| { $e['family'] == 'ipv4' }.map |$e| { $e['source'] }.unique.sort
+  $accept_v6_nets = $accept_entries.filter |$e| { $e['family'] == 'ipv6' }.map |$e| { $e['source'] }.unique.sort
+  $drop_v4_nets   = $drop_entries.filter   |$e| { $e['family'] == 'ipv4' }.map |$e| { $e['source'] }.unique.sort
+  $drop_v6_nets   = $drop_entries.filter   |$e| { $e['family'] == 'ipv6' }.map |$e| { $e['source'] }.unique.sort
+
+  # Ensure directory exists
+  file { '/etc/firewalld/ipsets':
+    ensure => directory,
+    mode   => '0755',
+  }
+
+  # Reload once if any ipset file changes (firewalld reads ipset XML on reload)
+  exec { 'firewalld-reload-for-ipsets':
+    command     => '/usr/bin/firewall-cmd --reload',
+    refreshonly => true,
+    path        => ['/usr/bin', '/bin'],
+  }
+
+  # Helper: manage one ipset + one rich rule referencing it
+  $manage_ipset = |String $name, String $family, Array[String] $nets, String $action, Integer $priority| {
+    $xml_family = $family ? { 'ipv4' => 'inet', 'ipv6' => 'inet6' }
+    $ipset_name = "${ipset_prefix}-${name}-${family}"         # e.g. dice-accept-ipv4
+    $ipset_file = "/etc/firewalld/ipsets/${ipset_name}.xml"
+
+    file { $ipset_file:
+      ensure  => file,
+      mode    => '0644',
+      content => epp('profile/firewalld/ipset.xml.epp', {
+          'name'    => $ipset_name,
+          'family'  => $xml_family,
+          'entries' => $nets,
+      }),
+      notify  => Exec['firewalld-reload-for-ipsets'],
+      require => File['/etc/firewalld/ipsets'],
+    }
+
+    # Use ipset as the rich rule source (puppet-firewalld supports source hash with ipset key)
+    firewalld_rich_rule { "DICE ipset ${name} ${family}":
+      ensure   => present,
+      zone     => $zone,
+      family   => $family,
+      source   => { 'ipset' => $ipset_name },
+      action   => $action,
+      priority => $priority,
+      require  => File[$ipset_file],
+    }
+  }
+
+  # IPv4 (only if there are entries)
+  if !empty($drop_v4_nets) { $manage_ipset('drop',   'ipv4', $drop_v4_nets,   'drop',   $drop_priority) }
+  if !empty($accept_v4_nets) { $manage_ipset('accept', 'ipv4', $accept_v4_nets, 'accept', $accept_priority) }
+
+  # IPv6 (may be empty on internal nodes)
+  if !empty($drop_v6_nets) { $manage_ipset('drop',   'ipv6', $drop_v6_nets,   'drop',   $drop_priority) }
+  if !empty($accept_v6_nets) { $manage_ipset('accept', 'ipv6', $accept_v6_nets, 'accept', $accept_priority) }
+
+  # Notes file with human context (titles + CIDRs)
+  file { $notes_path:
+    ensure  => file,
+    mode    => '0644',
+    content => epp('profile/firewalld/notes.txt.epp', {
+        'accept_entries'  => $accept_entries,
+        'drop_entries'    => $drop_entries,
+        'zone'            => $zone,
+        'ipset_prefix'    => $ipset_prefix,
+        'drop_priority'   => $drop_priority,
+        'accept_priority' => $accept_priority,
+    }),
+  }
+}

--- a/site/profile/manifests/firewalld/ipsets.pp
+++ b/site/profile/manifests/firewalld/ipsets.pp
@@ -96,6 +96,8 @@ define profile::firewalld::ipsets (
       ipset_prefix => $ipset_prefix,
     }
   }
+  notice("DICE firewalld: drop_v6_nets count=${drop_v6_nets.length} values=${drop_v6_nets}")
+  notice("DICE firewalld: accept_v6_nets count=${accept_v6_nets.length} values=${accept_v6_nets}")
 
   # Notes file with human context (titles + CIDRs)
   file { $notes_path:

--- a/site/profile/manifests/firewalld/ipsets.pp
+++ b/site/profile/manifests/firewalld/ipsets.pp
@@ -35,10 +35,15 @@ define profile::firewalld::ipsets (
     }
   }
 
-  $accept_v4_nets = $accept_entries.filter |$e| { $e['family'] == 'ipv4' }.map |$e| { $e['source'] }.unique.sort
-  $accept_v6_nets = $accept_entries.filter |$e| { $e['family'] == 'ipv6' }.map |$e| { $e['source'] }.unique.sort
-  $drop_v4_nets   = $drop_entries.filter   |$e| { $e['family'] == 'ipv4' }.map |$e| { $e['source'] }.unique.sort
-  $drop_v6_nets   = $drop_entries.filter   |$e| { $e['family'] == 'ipv6' }.map |$e| { $e['source'] }.unique.sort
+  $accept_v4_nets_raw = $accept_entries.filter |$e| { $e['family'] == 'ipv4' }.map |$e| { $e['source'] }.unique.sort
+  $accept_v6_nets_raw = $accept_entries.filter |$e| { $e['family'] == 'ipv6' }.map |$e| { $e['source'] }.unique.sort
+  $drop_v4_nets_raw   = $drop_entries.filter   |$e| { $e['family'] == 'ipv4' }.map |$e| { $e['source'] }.unique.sort
+  $drop_v6_nets_raw   = $drop_entries.filter   |$e| { $e['family'] == 'ipv6' }.map |$e| { $e['source'] }.unique.sort
+
+  $accept_v4_nets = profile::collapse_ipset_entries($accept_v4_nets_raw)
+  $accept_v6_nets = profile::collapse_ipset_entries($accept_v6_nets_raw)
+  $drop_v4_nets   = profile::collapse_ipset_entries($drop_v4_nets_raw)
+  $drop_v6_nets   = profile::collapse_ipset_entries($drop_v6_nets_raw)
 
   # Ensure directory exists
   file { '/etc/firewalld/ipsets':
@@ -96,8 +101,6 @@ define profile::firewalld::ipsets (
       ipset_prefix => $ipset_prefix,
     }
   }
-  notice("DICE firewalld: drop_v6_nets count=${drop_v6_nets.length} values=${drop_v6_nets}")
-  notice("DICE firewalld: accept_v6_nets count=${accept_v6_nets.length} values=${accept_v6_nets}")
 
   # Notes file with human context (titles + CIDRs)
   file { $notes_path:

--- a/site/profile/manifests/firewalld/ipsets.pp
+++ b/site/profile/manifests/firewalld/ipsets.pp
@@ -53,43 +53,49 @@ define profile::firewalld::ipsets (
     path        => ['/usr/bin', '/bin'],
   }
 
-  # Helper: manage one ipset + one rich rule referencing it
-  $manage_ipset = |String $name, String $family, Array[String] $nets, String $action, Integer $priority| {
-    $xml_family = $family ? { 'ipv4' => 'inet', 'ipv6' => 'inet6' }
-    $ipset_name = "${ipset_prefix}-${name}-${family}"         # e.g. dice-accept-ipv4
-    $ipset_file = "/etc/firewalld/ipsets/${ipset_name}.xml"
-
-    file { $ipset_file:
-      ensure  => file,
-      mode    => '0644',
-      content => epp('profile/firewalld/ipset.xml.epp', {
-          'name'    => $ipset_name,
-          'family'  => $xml_family,
-          'entries' => $nets,
-      }),
-      notify  => Exec['firewalld-reload-for-ipsets'],
-      require => File['/etc/firewalld/ipsets'],
-    }
-
-    # Use ipset as the rich rule source (puppet-firewalld supports source hash with ipset key)
-    firewalld_rich_rule { "DICE ipset ${name} ${family}":
-      ensure   => present,
-      zone     => $zone,
-      family   => $family,
-      source   => { 'ipset' => $ipset_name },
-      action   => $action,
-      priority => $priority,
-      require  => File[$ipset_file],
+  if !empty($drop_v4_nets) {
+    profile::firewalld::ipset { 'drop':
+      entries      => $drop_v4_nets,
+      family       => 'ipv4',
+      action       => 'drop',
+      zone         => $zone,
+      priority     => $drop_priority,
+      ipset_prefix => $ipset_prefix,
     }
   }
 
-  # IPv4 (only if there are entries)
-  if !empty($drop_v4_nets) { $manage_ipset('drop',   'ipv4', $drop_v4_nets,   'drop',   $drop_priority) }
-  if !empty($accept_v4_nets) { $manage_ipset('accept', 'ipv4', $accept_v4_nets, 'accept', $accept_priority) }
+  if !empty($accept_v4_nets) {
+    profile::firewalld::ipset { 'accept':
+      entries      => $accept_v4_nets,
+      family       => 'ipv4',
+      action       => 'accept',
+      zone         => $zone,
+      priority     => $accept_priority,
+      ipset_prefix => $ipset_prefix,
+    }
+  }
 
-  # IPv6 (may be empty on internal nodes)
-  if !empty($drop_v6_nets) { $manage_ipset('drop',   'ipv6', $drop_v6_nets,   'drop',   $drop_priority) }
-  if !empty($accept_v6_nets) { $manage_ipset('accept', 'ipv6', $accept_v6_nets, 'accept', $accept_priority) }
+  if !empty($drop_v6_nets) {
+    profile::firewalld::ipset { 'drop-v6':
+      entries      => $drop_v6_nets,
+      family       => 'ipv6',
+      action       => 'drop',
+      zone         => $zone,
+      priority     => $drop_priority,
+      ipset_prefix => $ipset_prefix,
+    }
+  }
+
+  if !empty($accept_v6_nets) {
+    profile::firewalld::ipset { 'accept-v6':
+      entries      => $accept_v6_nets,
+      family       => 'ipv6',
+      action       => 'accept',
+      zone         => $zone,
+      priority     => $accept_priority,
+      ipset_prefix => $ipset_prefix,
+    }
+  }
 
   # Notes file with human context (titles + CIDRs)
   file { $notes_path:

--- a/site/profile/templates/firewalld/ipset.xml.epp
+++ b/site/profile/templates/firewalld/ipset.xml.epp
@@ -1,0 +1,10 @@
+<%- | String $name, String $family, Array[String] $entries | -%>
+<?xml version="1.0" encoding="utf-8"?>
+<ipset type="hash:net">
+  <short><%= $name %></short>
+  <description>Managed by Puppet (DICE)</description>
+  <option name="family" value="<%= $family %>"/>
+<%- $entries.each |$net| { -%>
+  <entry><%= $net %></entry>
+<%- } -%>
+</ipset>

--- a/site/profile/templates/firewalld/notes.txt.epp
+++ b/site/profile/templates/firewalld/notes.txt.epp
@@ -7,11 +7,11 @@
 # This file preserves the original reason/title from Hiera.
 
 ## Drops
-<%- $drop_entries.sort_by |$e| { [$e['family'], $e['source']] }.each |$e| { -%>
+<%- $drop_entries.each |$e| { -%>
 <%= $e['family'] %>  <%= $e['source'] %>  -  <%= $e['title'] %>
 <%- } -%>
 
 ## Accepts
-<%- $accept_entries.sort_by |$e| { [$e['family'], $e['source']] }.each |$e| { -%>
+<%- $accept_entries.each |$e| { -%>
 <%= $e['family'] %>  <%= $e['source'] %>  -  <%= $e['title'] %>
 <%- } -%>

--- a/site/profile/templates/firewalld/notes.txt.epp
+++ b/site/profile/templates/firewalld/notes.txt.epp
@@ -1,0 +1,17 @@
+<%- | Array[Hash] $accept_entries, Array[Hash] $drop_entries, String $zone, String $ipset_prefix, Integer $drop_priority, Integer $accept_priority | -%>
+# Managed by Puppet (DICE)
+# Enforcement:
+#   - firewalld ipsets: /etc/firewalld/ipsets/<%= $ipset_prefix %>-{accept,drop}-{ipv4,ipv6}.xml (only when non-empty)
+#   - rich rules: 1 per ipset (priority drop=<%= $drop_priority %>, accept=<%= $accept_priority %>) in zone "<%= $zone %>"
+#
+# This file preserves the original reason/title from Hiera.
+
+## Drops
+<%- $drop_entries.sort_by |$e| { [$e['family'], $e['source']] }.each |$e| { -%>
+<%= $e['family'] %>  <%= $e['source'] %>  -  <%= $e['title'] %>
+<%- } -%>
+
+## Accepts
+<%- $accept_entries.sort_by |$e| { [$e['family'], $e['source']] }.each |$e| { -%>
+<%= $e['family'] %>  <%= $e['source'] %>  -  <%= $e['title'] %>
+<%- } -%>


### PR DESCRIPTION
We currently have > 800 rules in the firewall which take between 360-450s to process.
This PR implements `ipsets` for _most_ of the rules.
This combines the rules to 4 ipsets: one drop and one accept each for IPv4 and IPv6.

The only limitation are rules with ports (or without `source` like icmp), these remain rich rules.

All of the above reduces the number of rules to 18 on a public node and processing time goes down to ~50s (combined with the already merged change of ignoring $HOME for pool accounts).


EDIT: Tested on lcgce01 (not in production)